### PR TITLE
Feature/fix systemd

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mosquitto (2.0.20-1-wb102) stable; urgency=medium
+
+  * Install .service to /lib/systemd/system/ (instead of /usr/lib/systemd/system/)
+  * Define debhelper version in build-depends (for bullseye only)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Sun, 28 Apr 2025 19:49:02 +0300
+
 mosquitto (2.0.20-1-wb101) stable; urgency=medium
 
   * Backport to Bullseye

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Uploaders:
  Roger A. Light <roger@atchoo.org>,
  Joachim Zobel <jz-2017@heute-morgen.de>
 Build-Depends: debhelper-compat (= 13),
+               debhelper (<= 13.11.4),
                cmake,
                libcjson-dev,
                libdlt-dev,

--- a/debian/mosquitto.install
+++ b/debian/mosquitto.install
@@ -3,7 +3,7 @@ etc/mosquitto/certs/README
 etc/mosquitto/conf.d/README
 etc/mosquitto/mosquitto.conf
 etc/mosquitto/*.example
-usr/lib/systemd/system/mosquitto.service
+lib/systemd/system/mosquitto.service
 usr/bin/mosquitto_passwd
 usr/bin/mosquitto_ctrl
 usr/lib/*/mosquitto_dynamic_security.so*

--- a/debian/rules
+++ b/debian/rules
@@ -36,8 +36,8 @@ override_dh_auto_install:
 	install -d debian/tmp/etc/mosquitto/certs/
 	install -m 644 debian/README-certs debian/tmp/etc/mosquitto/certs/README
 	install -m 644 debian/mosquitto.conf debian/tmp/etc/mosquitto/mosquitto.conf
-	install -d debian/tmp/usr/lib/systemd/system/
-	install -m 644 ./service/systemd/mosquitto.service.notify debian/tmp/usr/lib/systemd/system/mosquitto.service
+	install -d debian/tmp/lib/systemd/system/
+	install -m 644 ./service/systemd/mosquitto.service.notify debian/tmp/lib/systemd/system/mosquitto.service
 
 override_dh_makeshlibs:
 	dh_makeshlibs -- -c4


### PR DESCRIPTION
собирая fit для cb8ea449, заметил, что mosquitto почему-то не стартует сам.

подебажив, вижу такое:
(неуспех, успех)
![image_2025-04-24_19-35-34](https://github.com/user-attachments/assets/ef9709a3-50ca-4b8e-9f74-6500714daad6)
![image_2025-04-24_19-36-50](https://github.com/user-attachments/assets/0bbf893f-e8fc-49fe-8b02-268d2c53321a)


посмотрел глубже: москитный сервис кладется в /usr/lib/systemd/..., а буллзайный debhelper в такое не умеет и хочет /lib/systemd/...

пруфы:
(debhelper после буллзая; debhelper буллзая)
![image](https://github.com/user-attachments/assets/d6b6a909-7155-44f8-be68-23a5f8cdc60d)
![image](https://github.com/user-attachments/assets/8dee5e62-fcf6-47c1-a606-fec9daefde9c)


как оно работало у нас на момент бекпорта - так и не понял (возможно, в девенве был какой-то свежий debheper от trixie); в какой-то момент похожие симптомы появились и при сборке стабильных fit-ов => надо вливать это; хуже не будет

проверял, собирая fit для cb8ea449 из тестинг-сета